### PR TITLE
Fix commands on cuDNN

### DIFF
--- a/docs/install_apt2.md
+++ b/docs/install_apt2.md
@@ -272,15 +272,15 @@ Install CuDNN
 
 * Enter the uncompress directory:
 
-        cd cudnn*
+        cd cuda
 
 * Copy the *.h files to your CUDA installation:
 
-        sudo cp *.h /usr/local/cuda/include/
+        sudo cp */*.h /usr/local/cuda/include/
 
 * Copy the *.so* files to your CUDA installation:
 
-        sudo cp *.so* /usr/local/cuda/lib64/
+        sudo cp */*.so* /usr/local/cuda/lib64/
 
 Configure and compile Caffe
 ---------------------------


### PR DESCRIPTION
Instructions on cuDNN is old fashioned because the layout of cuDNNv3 is changed to

```
cuda/:
include  lib64

cuda/include:
cudnn.h

cuda/lib64:
libcudnn.so  libcudnn.so.7.0  libcudnn.so.7.0.64  libcudnn_static.a
```